### PR TITLE
Removendo "verificaToken" de algumas rotas 

### DIFF
--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -7,7 +7,9 @@ const {
 const AutenticacaoController = require('../controller/autenticacaoController');
 const verificaToken = require('../midllewares/verificaToken');
 const autorizaFuncionario = require('../midllewares/autorizaFuncionario');
-const { AcompanhamentoController } = require('../controller/acompanhamentoController');
+const {
+  AcompanhamentoController,
+} = require('../controller/acompanhamentoController');
 const { AdicionalController } = require('../controller/adicionalController');
 const { SobremesaController } = require('../controller/sobremesaController');
 const { SanduicheController } = require('../controller/sanduicheController');
@@ -65,21 +67,33 @@ routes.put('/funcionario/:email', verificaToken, (req, res) =>
 
 // Acompanhamento
 const acompanhamentoController = new AcompanhamentoController();
-routes.get('/acompanhamento', verificaToken, (req, res) => {
+routes.get('/acompanhamento', (req, res) => {
   acompanhamentoController.itensCardapio(req, res);
 });
 routes.get('/acompanhamento/:id', verificaToken, (req, res) => {
   acompanhamentoController.itemCardapio(req, res);
 });
-routes.post('/acompanhamento/create', [verificaToken, autorizaFuncionario], (req, res) => {
-  acompanhamentoController.create(req, res);
-});
-routes.put('/acompanhamento/update/:id', [verificaToken, autorizaFuncionario],  (req, res) => {
-  acompanhamentoController.atualizarItem(req, res);
-});
-routes.delete('/acompanhamento/delete/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  acompanhamentoController.deletarItem(req, res);
-});
+routes.post(
+  '/acompanhamento/create',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    acompanhamentoController.create(req, res);
+  },
+);
+routes.put(
+  '/acompanhamento/update/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    acompanhamentoController.atualizarItem(req, res);
+  },
+);
+routes.delete(
+  '/acompanhamento/delete/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    acompanhamentoController.deletarItem(req, res);
+  },
+);
 
 // Adicional
 const adicionalController = new AdicionalController();
@@ -89,51 +103,87 @@ routes.get('/adicional/', verificaToken, (req, res) => {
 routes.get('/adicional/:id', verificaToken, (req, res) => {
   adicionalController.itemCardapio(req, res);
 });
-routes.post('/adicional/create', [verificaToken, autorizaFuncionario], (req, res) => {
-  adicionalController.create(req, res);
-});
-routes.put('/adicional/update/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  adicionalController.atualizarItem(req, res);
-});
-routes.delete('/adicional/delete/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  adicionalController.deletarItem(req, res);
-});
+routes.post(
+  '/adicional/create',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    adicionalController.create(req, res);
+  },
+);
+routes.put(
+  '/adicional/update/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    adicionalController.atualizarItem(req, res);
+  },
+);
+routes.delete(
+  '/adicional/delete/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    adicionalController.deletarItem(req, res);
+  },
+);
 
 // Bebida
 const bebidaController = new BebidaController();
-routes.get('/bebida/', verificaToken, (req, res) => {
+routes.get('/bebida/', (req, res) => {
   bebidaController.itensCardapio(req, res);
 });
 routes.get('/bebida/:id', verificaToken, (req, res) => {
   bebidaController.itemCardapio(req, res);
 });
-routes.post('/bebida/create', [verificaToken, autorizaFuncionario], (req, res) => {
-  bebidaController.create(req, res);
-});
-routes.put('/bebida/update/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  bebidaController.atualizarItem(req, res);
-});
-routes.delete('/bebida/delete/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  bebidaController.deletarItem(req, res);
-});
+routes.post(
+  '/bebida/create',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    bebidaController.create(req, res);
+  },
+);
+routes.put(
+  '/bebida/update/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    bebidaController.atualizarItem(req, res);
+  },
+);
+routes.delete(
+  '/bebida/delete/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    bebidaController.deletarItem(req, res);
+  },
+);
 
 // Sanduiche
 const sanduicheController = new SanduicheController();
-routes.get('/sanduiche/', verificaToken, (req, res) => {
+routes.get('/sanduiche/', (req, res) => {
   sanduicheController.itensCardapio(req, res);
 });
 routes.get('/sanduiche/:id', verificaToken, (req, res) => {
   sanduicheController.itemCardapio(req, res);
 });
-routes.post('/sanduiche/create', [verificaToken, autorizaFuncionario], (req, res) => {
-  sanduicheController.create(req, res);
-});
-routes.put('/sanduiche/update/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  sanduicheController.atualizarItem(req, res);
-});
-routes.delete('/sanduiche/delete/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  sanduicheController.deletarItem(req, res);
-});
+routes.post(
+  '/sanduiche/create',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sanduicheController.create(req, res);
+  },
+);
+routes.put(
+  '/sanduiche/update/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sanduicheController.atualizarItem(req, res);
+  },
+);
+routes.delete(
+  '/sanduiche/delete/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sanduicheController.deletarItem(req, res);
+  },
+);
 
 // Sobremesa
 const sobremesaController = new SobremesaController();
@@ -143,14 +193,26 @@ routes.get('/sobremesa/', verificaToken, (req, res) => {
 routes.get('/sobremesa/:id', verificaToken, (req, res) => {
   sobremesaController.itemCardapio(req, res);
 });
-routes.post('/sobremesa/create', [verificaToken, autorizaFuncionario], (req, res) => {
-  sobremesaController.create(req, res);
-});
-routes.put('/sobremesa/update/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  sobremesaController.atualizarItem(req, res);
-});
-routes.delete('/sobremesa/delete/:id', [verificaToken, autorizaFuncionario], (req, res) => {
-  sobremesaController.deletarItem(req, res);
-});
+routes.post(
+  '/sobremesa/create',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sobremesaController.create(req, res);
+  },
+);
+routes.put(
+  '/sobremesa/update/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sobremesaController.atualizarItem(req, res);
+  },
+);
+routes.delete(
+  '/sobremesa/delete/:id',
+  [verificaToken, autorizaFuncionario],
+  (req, res) => {
+    sobremesaController.deletarItem(req, res);
+  },
+);
 
 module.exports = routes;


### PR DESCRIPTION
Algumas rotas devem ser consultadas de forma publica. Logo função de verificação do token inviabiliza isso. Foram removidas apenas das rotas de get que são necessários no cardápio.